### PR TITLE
Fix Privacy Policy Title

### DIFF
--- a/views/viewer/privacy_policy.ejs
+++ b/views/viewer/privacy_policy.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Terms and Conditions</title>
+    <title>Privacy Policy</title>
 </head>
 <body>
 <h3>Your privacy is critically important to us.</h3>


### PR DESCRIPTION
The title of the Privacy Policy page says Terms and Conditions, when it should say Privacy Policy.