### PR TITLE
Stable 6.5.10 (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixed
 - <github issue="183">Fix issue where syncing assignments with new categories breaks editing weights until refresh</github>
 - Fixed issue with sync log showing [Removed] after a sync that brought in new categories.
+- "a" shortcut for adding assignments now works even if a class has no assignments at all.
 
 ## [Stable 6.5.9] - 2024-02-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
 ## [Known Issues] - <em>Send bug reports in More > Send Feedback</em><br><em>Only issues in the stable version will be listed here</em>
 - None
 
+## [Stable 6.5.10] - 2024-02-13
+### Fixed
+- <github issue="183">Fix issue where syncing assignments with new categories breaks editing weights until refresh</github>
+- Fixed issue with sync log showing [Removed] after a sync that brought in new categories.
+
 ## [Stable 6.5.9] - 2024-02-12
 ### Fixed
 - <github issue="181">Fix analytics page (broken after db restructure)</github>

--- a/views/user/authorized_index.ejs
+++ b/views/user/authorized_index.ejs
@@ -1551,7 +1551,7 @@
                 return {updated: true};
             }
             clearTimeout(checkLastUpdated);
-            return {updated: true};
+            return {updated: false};
         }
 
         function disableScrolling() {

--- a/views/user/authorized_index.ejs
+++ b/views/user/authorized_index.ejs
@@ -4494,7 +4494,7 @@
                     showCard("#shortcutsDisplay");
                 }
             } else if (["a", "A"].includes(e.key)) {
-                if (currentPage === -1 || cardsDisplayed.length != 0 || !(Object.keys(weights[currentPage].weights).length + Object.keys(addedWeights[currentPage].weights).length)) {
+                if (currentPage === -1 || cardsDisplayed.length != 0) {
                     return;
                 }
                 if ($($(".add-assignment-container")[currentPage]).hasClass("active")) {


### PR DESCRIPTION
- Fixes #183 
- Should fix issue with sync log showing [Removed]
- Makes add assignment shortcut work even if no assignments (The limitation is a relic of the pre-"new category" era)