### PR TITLE
Stable 6.5.11 (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
 ## [Known Issues] - <em>Send bug reports in More > Send Feedback</em><br><em>Only issues in the stable version will be listed here</em>
 - None
 
+## [Stable 6.5.11] - 2024-02-15
+### Fixed
+- Issue where users whose latest sync contained changes to a course with dots in the name (e.g. U.S. History AP) could not view past semesters
+- Cursor not being a pointer when hovering over the sync status in old semesters
+
 ## [Stable 6.5.10] - 2024-02-13
 ### Fixed
 - <github issue="183">Fix issue where syncing assignments with new categories breaks editing weights until refresh</github>

--- a/server/dbClient.js
+++ b/server/dbClient.js
@@ -4626,9 +4626,9 @@ const _getTrimmedAlerts = async (db, username, term, semester) => {
 
     let {term: latestTerm, semester: latestSemester} = (await _getMostRecentTermData(db, username)).data.value;
 
-    let latest = res.data.value.alerts.lastUpdated.length > 0 ? res.data.value.alerts.lastUpdated.slice(-1)[0] : null;
+    let exists = res.data.value.alerts.lastUpdated.length > 0;
     let aggregation;
-    if (term !== latestTerm || semester !== latestSemester || latest === null) {
+    if (term !== latestTerm || semester !== latestSemester || !exists) {
         aggregation = [
             {
                 $match: {
@@ -4639,10 +4639,10 @@ const _getTrimmedAlerts = async (db, username, term, semester) => {
                     alerts: 1
                 }
             }, {
-                $unset: 'alerts.lastUpdated'
-            }, {
                 $addFields: {
-                    alerts: {lastUpdated: latest !== null ? [latest] : []}
+                    "alerts.lastUpdated": {
+                        $slice: ["$alerts.lastUpdated", -1]
+                    }
                 }
             }
         ]
@@ -4666,11 +4666,9 @@ const _getTrimmedAlerts = async (db, username, term, semester) => {
                 }
             }, {
                 $addFields: {
-                    alerts: {
-                        lastUpdated: {
-                            $filter: {
-                                input: "$alerts.lastUpdated", as: "updateObj", cond: cond
-                            }
+                    "alerts.lastUpdated": {
+                        $filter: {
+                            input: "$alerts.lastUpdated", as: "updateObj", cond: cond
                         }
                     }
                 }

--- a/views/partials/user/navbar.ejs
+++ b/views/partials/user/navbar.ejs
@@ -56,7 +56,7 @@
                            onclick="showCard('#gradeChangesCardDisplay')"
                            class="updateGradesMessage alert-info">
                         <span></span>
-                        <div <% if (_alerts.lastUpdated.length && !history) { %>style="cursor: pointer"<% } %> class="messageTxt">Loading Sync Status...</div>
+                        <div style="cursor: pointer" class="messageTxt">Loading Sync Status...</div>
                     </label>
                     <span class="popup popup-holder">
                         <span id="navinfoPopup"


### PR DESCRIPTION
### Fixed
- Issue where users whose latest sync contained changes to a course with dots in the name (e.g. U.S. History AP) could not view past semesters
- Cursor not being a pointer when hovering over the sync status in old semesters