### PR TITLE
Stable 6.7.0 (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@
 ## [Known Issues] - <em>Send bug reports in More > Send Feedback</em><br><em>Only issues in the stable version will be listed here</em>
 - None
 
+## [Stable 6.6.5] - 2024-03-11
+### Improved
+- More sports are now recognized as non-academic<ul>
+- Specifically added Swimming, Baseball, Volleyball, Tennis, Lacrosse, Golf, Soccer, and Basketball (in addition to existing Football, Water Polo, Track, and Cross Country)</ul>
+
+### Fixed
+- Some old typos in the changelog
+
 ## [Stable 6.6.4] - 2024-02-16
 ### Fixed
 - Issue linking Discord or using API keys if you began the process before 6.6.0.
@@ -499,7 +507,7 @@
 - Locked scraper now also fetches empty courses
 - Sync log will no longer show all assignments as new/removed when the number of courses changes
 - Class colors now stay the same after hiding/unhiding non-academic classes
-- Cura has been set as a non-academic class by default, as well as several Sports and Study hHalls
+- Cura has been set as a non-academic class by default, as well as several Sports and Study Hall
 - If a Bellarmine course has no grades and no set class type in the catalog, and a user has non-academic course display disabled, a message now appears asking them to send feedback about whether the class is non-academic or not
 
 ### Fixed
@@ -3249,7 +3257,7 @@
 - Choosing a class in update weights now changes the class page behind it
 
 ### Fixed
-- <em>Mobile</em> Issues with mobile navbar
+- <em>[Mobile]</em> Issues with mobile navbar
 
 ## [Beta 0.2.19] - 2019-12-09
 ### Improved
@@ -3471,7 +3479,7 @@
 
 ## [Beta 0.1.1] - 2019-10-14
 ### Improved
-- <em>Mobile</em> Scaling on mobile
+- <em>[Mobile]</em> Scaling on mobile
 
 ## [Beta 0.1.0] - 2019-10-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,17 @@
 ## [Known Issues] - <em>Send bug reports in More > Send Feedback</em><br><em>Only issues in the stable version will be listed here</em>
 - None
 
-## [Stable 6.6.5] - 2024-03-11
+## [Stable 6.7.0] - 2024-03-12
+### Added
+- <em>[Mobile]</em> <github issue="190">Add GPA to Mobile Site</github>
+- Term Switcher has been moved to the right side of the screen
+
 ### Improved
 - More sports are now recognized as non-academic<ul>
 - Specifically added Swimming, Baseball, Volleyball, Tennis, Lacrosse, Golf, Soccer, and Basketball (in addition to existing Football, Water Polo, Track, and Cross Country)</ul>
+- When the changelog is opened with a specific version, it will now scroll the legend to that version.
+- <em>[Mobile]</em> Improved the appearance of the changelog on mobile
+- <em>[Mobile]</em> Tapping outside the term switcher, GPA popout, or notification panel now just closes them instead of also clicking things.
 
 ### Fixed
 - Some old typos in the changelog

--- a/public/css/blur.css
+++ b/public/css/blur.css
@@ -14,11 +14,6 @@
         -webkit-backdrop-filter: blur(0.5rem);
     }
 
-    #termSwitcher.blur {
-        backdrop-filter: blur(0.2rem);
-        -webkit-backdrop-filter: blur(0.2rem);
-    }
-
     #termSwitcher > div.blur {
         backdrop-filter: blur(1rem);
         -webkit-backdrop-filter: blur(1rem);
@@ -36,5 +31,24 @@
 
     div.unlock-with {
         backdrop-filter: blur(2px);
+    }
+
+    /* Mobile Stuff */
+    @media only screen and (max-width: 991px) {
+        #termSwitcher {
+            background-color: unset !important;
+        }
+
+        #clickBarrier.blocking {
+            background: transparent !important;
+            backdrop-filter: blur(0.2rem);
+            -webkit-backdrop-filter: blur(0.2rem);
+        }
+
+        #GPA-container {
+            background: transparent !important;
+            backdrop-filter: blur(0.5rem);
+            -webkit-backdrop-filter: blur(0.5rem);
+        }
     }
 }

--- a/public/css/dark_blur.css
+++ b/public/css/dark_blur.css
@@ -16,7 +16,7 @@
         opacity: 1 !important;
     }
 
-    #termSwitcher:hover, #termSwitcher.hover, #termSwitcher::before, #termSwitcher:hover::before {
+    #termSwitcher:hover, #termSwitcher.hover, #termSwitcher::before, #GPA-container::before {
         box-shadow: black 0 0 10px 1px;
     }
 

--- a/public/css/dark_mode.css
+++ b/public/css/dark_mode.css
@@ -708,4 +708,26 @@ div.assignment-info:hover {
         color: rgb(138.5, 138.5, 138.5);
         background-color: #111111;
     }
+
+    #GPA-container {
+        border: 1px solid black;
+        background-color: #191919;
+        box-shadow: black 0 0 10px 1px;
+    }
+
+    #GPA-container::before {
+        border: 1px solid black;
+    }
+
+    #GPA-container:hover, #GPA-container.hover {
+        background-color: #191919;
+    }
+
+    #clickBarrier.blocking {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    #changelog-legend-column {
+        background-color: #222222;
+    }
 }

--- a/public/css/light_blur.css
+++ b/public/css/light_blur.css
@@ -28,4 +28,11 @@
     #infoAverage > div.unlock-with {
         color: #222;
     }
+
+    /* Mobile Stuff */
+    @media only screen and (max-width: 991px) {
+        #GPA-container::before {
+            box-shadow: rgba(51, 51, 51, 0.2) 0 0 2px 1px, inset rgba(255, 255, 255, 0.5) 0 0 200px 5px;
+        }
+    }
 }

--- a/public/css/light_mode.css
+++ b/public/css/light_mode.css
@@ -694,4 +694,29 @@ div.assignment-info:hover {
     .table-container {
         background-color: #FFFFFF;
     }
+
+    #GPA-container {
+        border: 1px solid #CCCCCC;
+        background-color: #FFFFFF;
+    }
+
+    #GPA-container::before {
+        border: 1px solid #CCCCCC;
+    }
+
+    #GPA-container:hover {
+        background-color: #FFFFFF;
+    }
+
+    #GPA-container div {
+        border: 1px solid #CCCCCC;
+    }
+
+    #clickBarrier.blocking {
+        background-color: rgba(255,255,255,0.5);
+    }
+
+    #changelog-legend-column {
+        border: 2px solid #CCCCCC;
+    }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1898,49 +1898,54 @@ div:not(#dismissed-notifications) > .notification-card.important.discord {
     position: fixed;
     z-index: 19;
     top: 50%;
-    left: -6rem;
+    right: -8rem;
     width: 8rem;
     min-height: 12rem;
     height: unset;
-    padding: 0.5rem 2.5rem 0.5rem 0.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 2.5rem;
     transition: 250ms all 150ms ease;
     transform: translateY(-50%);
     text-align: center;
-    border-radius: 0 1rem 1rem 0;
+    border-radius: 1rem 0 0 1rem;
 }
 
-#termSwitcher::before {
+#termSwitcher::before, #termSwitcher::after {
     z-index: 2;
     font-weight: 500;
     position: absolute;
     top: 50%;
-    left: 3rem;
+    right: 5rem;
     width: 5rem;
-    min-height: 12rem;
-    height: 100%;
+    height: 12rem;
     padding: 0.1rem;
     content: "Term Switcher";
     transition: all 500ms ease;
     transform: translateY(-50%);
     text-align: center;
     vertical-align: middle;
-    border-radius: 0 1rem 1rem 0;
+    border-radius: 1rem 0 0 1rem;
     background-color: inherit;
     box-shadow: inherit;
-    writing-mode: vertical-rl;
+    writing-mode: vertical-lr;
     text-orientation: sideways;
 }
 
-#termSwitcher:hover, #termSwitcher.hover {
-    min-height: 12rem;
-    padding-right: 0.5rem;
-    height: unset;
-    width: 6rem;
-    left: 0;
+#termSwitcher::after {
+    opacity: 0;
+    transition: 0ms all 500ms ease;
+    /* pointer-events: all; */
 }
 
-#termSwitcher:hover::before, #termSwitcher.hover::before {
-    left: -6rem;
+#termSwitcher:hover, #termSwitcher.hover {
+    padding-left: 0.5rem;
+    width: 6rem;
+    right: 0;
+}
+
+#termSwitcher:hover::before, #termSwitcher.hover::before,
+#termSwitcher:hover::after, #termSwitcher.hover::after {
+    right: -6rem;
+    height: 100%;
 }
 
 #termSwitcher > div {
@@ -4280,7 +4285,7 @@ input[name=searchByNameOrUsername] {
         border-radius: 0.5rem;
     }
 
-    #GPA-container, .chart-container, #classLinks {
+    .chart-container, #classLinks {
         display: none;
     }
 
@@ -4462,6 +4467,99 @@ input[name=searchByNameOrUsername] {
         transform: none;
         opacity: 1;
         pointer-events: all;
+    }
+
+    #clickBarrier {
+        position: fixed;
+        width: 100%;
+        height: 100%;
+        z-index: 19;
+        top: 0;
+        left: 0;
+        pointer-events: none;
+        background-color: transparent;
+        transition: all 250ms ease;
+    }
+
+    #clickBarrier.blocking {
+        pointer-events: all;
+    }
+
+    #GPA-container {
+        z-index: 20;
+        position: fixed;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 14rem;
+        height: 30rem;
+        padding: 2rem;
+        left: -15rem;
+        transition: 250ms all 150ms ease;
+        border-radius: 0 1rem 1rem 0;
+    }
+
+    #GPA-container:hover {
+        left: 0;
+    }
+
+    #GPA-container::before, #GPA-container::after {
+        content: "GPA";
+        font-weight: bold;
+        position: absolute;
+        width: 16rem;
+        height: 4rem;
+        padding: 0.5rem;
+        left: 2rem;
+        top: 50%;
+        transform: translateY(-50%);
+        text-align: right;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        vertical-align: middle;
+        transition: all 500ms ease;
+        border-radius: 0 1rem 1rem 0;
+        background-color: inherit;
+    }
+
+    #GPA-container::after {
+        opacity: 0;
+        transition: 0ms all 500ms ease;
+    }
+
+    #GPA-container:hover::before, #GPA-container:hover::after {
+        left: -16.5rem;
+        height: 100%;
+    }
+
+    #gpaDetailsBtn {
+        display: none;
+    }
+
+    #notificationPanel::before {
+        top: -3rem;
+    }
+
+    #notificationPanel::after {
+        top: 8.5rem;
+    }
+
+    .changelog-parent {
+        flex-direction: column-reverse;
+    }
+
+    .changelog {
+        max-height: 40vh;
+        border-radius: 1rem;
+        overflow: hidden;
+        margin-bottom: 1rem;
+    }
+
+    .changelog-legend-column {
+        max-width: 100%;
+        max-height: 20vh;
+        padding: 0 1rem;
+        border-radius: 0.5rem;
     }
 }
 

--- a/server/dbClient.js
+++ b/server/dbClient.js
@@ -4432,6 +4432,14 @@ const _getRelevantClassData = async (db, username, term, semester) => {
             nonAcademicOverride ||= userClass.className.endsWith("Track");
             nonAcademicOverride ||= userClass.className.endsWith("Water Polo");
             nonAcademicOverride ||= userClass.className.endsWith("Football");
+            nonAcademicOverride ||= userClass.className.endsWith("Swimming");
+            nonAcademicOverride ||= userClass.className.endsWith("Baseball");
+            nonAcademicOverride ||= userClass.className.endsWith("Volleyball");
+            nonAcademicOverride ||= userClass.className.endsWith("Tennis");
+            nonAcademicOverride ||= userClass.className.endsWith("Lacrosse");
+            nonAcademicOverride ||= userClass.className.endsWith("Golf");
+            nonAcademicOverride ||= userClass.className.endsWith("Soccer");
+            nonAcademicOverride ||= userClass.className.endsWith("Basketball");
             nonAcademicOverride ||= userClass.className === "Study Hall";
             nonAcademicOverride ||= userClass.className === "Free Period";
             nonAcademicOverride ||= userClass.className.startsWith("Study Center");

--- a/views/partials/user/changelog.ejs
+++ b/views/partials/user/changelog.ejs
@@ -107,7 +107,8 @@
             changelogContainer.html("");
             changelogContainer.addClass("placeholder");
             return;
-        } else if (!(version in cachedHTML)) {
+        }
+        if (!(version in cachedHTML)) {
             $.ajax({
                        url: "/changelog", type: "GET", async: true, data: {versionName: version}
                    }).done((response) => {
@@ -127,6 +128,10 @@
         changelogContainer.removeClass("placeholder");
         changelogLegendReferences.forEach((v) => v.removeClass("active"));
         changelogLegendReferences[idx].addClass("active");
+        changelogLegendColumn.animate({
+            scrollTop:
+                changelogLegendColumn.scrollTop() + changelogLegendReferences[idx].position().top - changelogLegendColumn.height() / 2 + changelogLegendReferences[idx].height() / 2
+        });
         if (version === latestVersion) {
             $.ajax({
                        url: "/latestVersionSeen", type: "POST", async: true

--- a/views/partials/user/navbar.ejs
+++ b/views/partials/user/navbar.ejs
@@ -235,6 +235,8 @@
 <% if (page === "home") { %>
     <%- include('assignment_info.ejs', {theme: theme}); %>
 <% } %>
+<!-- Click Barrier -->
+<div id="clickBarrier"></div>
 
 <!-- Custom JavaScript -->
 <script>

--- a/views/partials/user/notification_panel.ejs
+++ b/views/partials/user/notification_panel.ejs
@@ -1,6 +1,6 @@
 <div id="notificationPanel" class="blur">
     <btn class="btn btn-md"
-         onclick="$('#notificationPanel').removeClass('active');"
+         onclick="$('#notificationPanel').removeClass('active'); unblockClicks()"
          style="position: absolute; width: fit-content; width: -moz-fit-content; left: 0; top: 0">
         <i class="fa fa-close" aria-hidden="true"></i> Close
     </btn>
@@ -31,6 +31,7 @@
         if ($(e.target).is("#notificationPanel:not(.active)") || (!$(e.target).is(".notification-btns span, .notification-message *") && $(e.target).parents("#notificationPanel:not(.active) #pinned-notifications .notification-card").length)) {
             $("#notifications").animate({scrollTop: 0}, 0);
             $("#notificationPanel").addClass("active");
+            blockClicks();
         }
     });
 

--- a/views/user/authorized_index.ejs
+++ b/views/user/authorized_index.ejs
@@ -190,7 +190,7 @@
                                                 style="margin-left: 0.4rem"><span
                                                     class="popup-right-top">Your cumulative GPA is calculated from
                                                 all
-                                                your courses taken so far. However, it does not include pe or
+                                                your courses taken so far. However, it does not include P.E. or
                                                 summer classes.</span></i></span></h5>
                                 <h5 id="GPA-display-cumulative"><span>----
                                         <% if (_appearance.showMaxGPA) { %>/----
@@ -257,13 +257,12 @@
                                 <% if (i % 2 === 1) {
                                     continue;
                                 } %>
-                                <div class="block">
+                                <div class="block" id="block<%= i + offset; %>">
                                     <table>
                                         <thead>
                                         <tr>
                                             <th id="overview<%= i + offset; %>" class="overview"
-                                                style="cursor: pointer; text-align: center; color: <%= _appearance.classColors[i]; %>"
-                                                onclick="showPage(<%= i + offset; %>)">
+                                                style="cursor: pointer; text-align: center; color: <%= _appearance.classColors[i]; %>">
                                                 <%= _gradeData[i].class_name; %>
                                             </th>
                                         </tr>
@@ -271,8 +270,7 @@
                                         <tbody>
                                         <tr>
                                             <td class="overview"
-                                                style="padding-top: 0.5rem; padding-bottom: 0; cursor: pointer; color: <%= _appearance.classColors[i]; %>"
-                                                onclick="showPage(<%= i + offset; %>)">
+                                                style="padding-top: 0.5rem; padding-bottom: 0; cursor: pointer; color: <%= _appearance.classColors[i]; %>">
                                                 <div id="overviewChart<%= i + offset; %>"
                                                      style="display:block; font-weight:bolder">
                                                     <div style="color: <%= _appearance.classColors[i]; %> !important">
@@ -297,13 +295,12 @@
                         <% for (let i = 0; i < _gradeData.length; i++) { %>
                             <% if (_appearance.showNonAcademic || _relevantClassData[_gradeData[i].class_name]["classType"] !== "non-academic") { %>
                                 <% if (i % 2 === 0) continue; %>
-                                <div class="block">
+                                <div class="block" id="block<%= i + offset; %>">
                                     <table>
                                         <thead>
                                         <tr>
                                             <th id="overview<%= i + offset; %>" class="overview"
-                                                style="cursor: pointer; text-align: center; color: <%= _appearance.classColors[i]; %>"
-                                                onclick="showPage(<%= i + offset; %>)">
+                                                style="cursor: pointer; text-align: center; color: <%= _appearance.classColors[i]; %>">
                                                 <%= _gradeData[i].class_name; %>
                                             </th>
                                         </tr>
@@ -311,8 +308,7 @@
                                         <tbody>
                                         <tr>
                                             <td class="overview"
-                                                style="padding-top: 0.5rem; padding-bottom: 0; cursor: pointer; color: <%= _appearance.classColors[i]; %>"
-                                                onclick="showPage(<%= i + offset; %>)">
+                                                style="padding-top: 0.5rem; padding-bottom: 0; cursor: pointer; color: <%= _appearance.classColors[i]; %>">
                                                 <div id="overviewChart<%= i + offset; %>"
                                                      style="display:block; font-weight:bolder">
                                                     <div style="color: <%= _appearance.classColors[i]; %> !important">
@@ -4549,7 +4545,13 @@
                 }
             } else if ((["n", "N"]).includes(e.key)) {
                 if (cardsDisplayed.length === 0) {
-                    $("#notificationPanel").toggleClass("active");
+                    let nPanel = $("#notificationPanel");
+                    nPanel.toggleClass("active");
+                    if (nPanel.hasClass("active")) {
+                        blockClicks();
+                    } else {
+                        unblockClicks();
+                    }
                 }
             } else if (_.inRange(e.key, 1, data.length + 1)) {
                 if (cardsDisplayed.length === 0) {
@@ -5129,7 +5131,37 @@
             }
             if (!$(e.target).is("#notificationPanel") && !$(e.target).parents("#notificationPanel").length && $("#notificationPanel").hasClass("active")) {
                 $("#notificationPanel").removeClass("active");
+                unblockClicks();
             }
+        });
+
+        function blockClicks() {
+            $("#clickBarrier").addClass("blocking");
+        }
+
+        function unblockClicks() {
+            if (!$("#termSwitcher").is(":hover") && !$("#GPA-container").is(":hover") && !$("#notificationPanel").hasClass("active")) {
+                $("#clickBarrier").removeClass("blocking");
+            }
+        }
+
+        $("#clickBarrier").on("click", function (e) {
+            e.stopPropagation();
+        });
+
+        $("#termSwitcher, #GPA-container").hover(function (e) {
+            blockClicks();
+        }, function (e) {
+            setTimeout(unblockClicks, 0); // Forces this to execute after the click is blocked
+        });
+
+        $("#mobile-overview-grid th, #mobile-overview-grid td").on("click", function (e) {
+            let target = $(e.target);
+            if (!target.is(".block")) {
+                target = target.parents(".block");
+            }
+            let index = target[0].id.substring("block".length);
+            showPage(parseInt(index));
         });
 
         function checkNewCategory(inputID, messageDivID, index) {


### PR DESCRIPTION
### Added
- <em>[Mobile]</em> #190 
- Term Switcher has been moved to the right side of the screen

### Improved
- More sports are now recognized as non-academic<ul>
- Specifically added Swimming, Baseball, Volleyball, Tennis, Lacrosse, Golf, Soccer, and Basketball (in addition to existing Football, Water Polo, Track, and Cross Country)</ul>
- When the changelog is opened with a specific version, it will now scroll the legend to that version.
- <em>[Mobile]</em> Improved the appearance of the changelog on mobile
- <em>[Mobile]</em> Tapping outside the term switcher, GPA popout, or notification panel now just closes them instead of also clicking things.

### Fixed
- Some old typos in the changelog

Also, various styling improvements and fixes