### PR TITLE
Filter users that have never synced from user count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,21 @@
 ## [Known Issues] - <em>Send bug reports in More > Send Feedback</em><br><em>Only issues in the stable version will be listed here</em>
 - None
 
-## [Stable 6.9.3] - 2024-03-28
+## [Stable 6.9.4] - 2024-03-29
 ### Added
 - Button to change school password in Account Settings<ul>
 - This was already possible by disabling/reenabling GradeSync, but it is more explicit now</ul>
 
 ### Fixed
 - Password Reset works now
-//- <em>[Mobile]</em> Fix class tile not clickable on iOS
+
+## [Beta 6.9.3] - 2024-03-28
+### Added
+- Button to change school password in Account Settings<ul>
+- This was already possible by disabling/reenabling GradeSync, but it is more explicit now</ul>
+
+### Fixed
+- Password Reset works now
 
 ## [Stable 6.9.2] - 2024-03-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 - Button to change school password in Account Settings<ul>
 - This was already possible by disabling/reenabling GradeSync, but it is more explicit now</ul>
 
+### Improved
+- User counts on the charts page now only include users that have successfully synced at least once.
+
 ### Fixed
 - Password Reset works now
 

--- a/server/process_chart_data.js
+++ b/server/process_chart_data.js
@@ -130,8 +130,8 @@ async function run() {
     }
 
     time = Date.now();
-    let actualAllUsers = (await _getAllUsers(db, {"loggedIn": 1, 'personalInfo.graduationYear': 1})).data.value
-        .concat(await db.collection(ARCHIVED_USERS_COLLECTION_NAME).find({}, {projection: {"loggedIn": 1, 'personalInfo.graduationYear': 1}}).toArray());
+    let actualAllUsers = (await _getAllUsers(db, {"loggedIn": 1, 'personalInfo.graduationYear': 1}, {"alerts.lastUpdated": {$not: {$size: 0}}})).data.value
+        .concat(await db.collection(ARCHIVED_USERS_COLLECTION_NAME).find({"alerts.lastUpdated": {$not: {$size: 0}}}, {projection: {"loggedIn": 1, 'personalInfo.graduationYear': 1}}).toArray());
 
     // Might be workaround for this, but I can't figure it out at the moment
     let userData = loginData.map(t => ({

--- a/views/viewer/cool_charts.ejs
+++ b/views/viewer/cool_charts.ejs
@@ -308,7 +308,7 @@
     }
     let updated = new Date(<%= lastUpdated - 24 * 60 * 60 * 1000 %>);
     let count = <%- JSON.stringify(_loggedInData.data.value) %>;
-    $("#user-desc").text(`${Object.values(userData.slice(-1)[0].y).reduce((a, b) => a + b, 0)} total user(s) as of ${updated.toDateString()}.`);
+    $("#user-desc").text(`${Object.values(userData.slice(-1)[0].y).reduce((a, b) => a + b, 0)} total real user(s) as of ${updated.toDateString()}.`);
     $("#curr-logins").text(`${count.count} active session(s). ${count.uniqueCount} currently active user(s).`);
     $("#weekday-desc").text(`${weekdayLoginData.reduce((a, b) => a + b, 0)} logins, ${weekdaySyncData.reduce((a, b) => a + b, 0)} syncs all time`)
 


### PR DESCRIPTION
- User counts on the charts page now only include users that have successfully synced at least once.