### PR TITLE
Fixes PowerSchool Sync URL

### DIFF
--- a/server/scrape.py
+++ b/server/scrape.py
@@ -317,7 +317,7 @@ class PowerschoolScraper(Scraper):
 
         # First request
         self.message = "Logging in."
-        url = "https://powerschool.bcp.org/guardian/home.html"
+        url = "https://powerschool.bcp.org/student/idp?_userTypeHint=student"
         resp = self.get_with_retries(url, headers=headers_1)
         soup = bS(resp.text, "html.parser")
 


### PR DESCRIPTION
The old URL that was used to sync classes links to the PowerSchool login page, whereas this new URL automatically links to the Bellarmine login page for PowerSchool.